### PR TITLE
Changing the link of 'Duvidas frequentes'

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -109,7 +109,7 @@ module.exports = {
             },
             {
               label: 'Dúvidas frequentes',
-              href: 'https://ajudaempresas.picpay.com/hc/pt-br/categories/360004972752-PicPay-Studio-',
+              href: 'https://ajudaempresas.picpay.com/hc/pt-br/categories/360003836611-PicPay-E-commerce',
             },
             {
               label: 'PicPay.com',


### PR DESCRIPTION
Changing the link of 'Duvidas frequentes' to -> https://ajudaempresas.picpay.com/hc/pt-br/categories/360003836611-PicPay-E-commerce