### PR TITLE
Devolver o id externo nas respostas (charge, refund e consulta)

### DIFF
--- a/static/swagger/picpay-1-click-en.json
+++ b/static/swagger/picpay-1-click-en.json
@@ -822,6 +822,11 @@
             "description": "Identifier of the canceled transaction, or of the new transaction created for cases of partial refund.",
             "example": "123456222"
           },
+          "reference_id": {
+            "type": "string",
+            "description": "Unique payment identifier in the partner.",
+            "example": "123456222"
+          },
           "created_at": {
             "type": "string",
             "example": "2020-04-16 20:59:58",
@@ -877,6 +882,11 @@
           "transaction_id": {
             "type": "string",
             "description": "Identifier of the created transaction.",
+            "example": "123456222"
+          },
+          "reference_id": {
+            "type": "string",
+            "description": "Unique payment identifier in the partner.",
             "example": "123456222"
           },
           "created_at": {

--- a/static/swagger/picpay-1-click.json
+++ b/static/swagger/picpay-1-click.json
@@ -822,6 +822,11 @@
             "description": "Identificador da transação cancelada, ou da nova transação criada para os casos de ao reembolso parcial.",
             "example": "123456222"
           },
+          "reference_id": {
+            "type": "string",
+            "description": "Identificador único do pagamento no parceiro.",
+            "example": "123456222"
+          },
           "created_at": {
             "type": "string",
             "example": "2020-04-16 20:59:58",
@@ -877,6 +882,11 @@
           "transaction_id": {
             "type": "string",
             "description": "Identificador da transação criada.",
+            "example": "123456222"
+          },
+          "reference_id": {
+            "type": "string",
+            "description": "Identificador único do pagamento no parceiro.",
             "example": "123456222"
           },
           "created_at": {


### PR DESCRIPTION
### Contexto
Existe um padrão de algumas APIs de retornar todos os campos recebidos na criação de um recurso, o qual permite a validação de solicitante de que os dados enviados foram corretamente recebidos e processados. Um cenário onde isso pode ocorrer é quando um seller envia um campo com nome errado, por exemplo reference_id incorretamente enviado como referenceId , e pode confirmar o nosso recebimento e seu valor através da resposta, que contém o campo correto.

### O que foi desenvolvido
Adicionado no responseBody de charge e refund o reference_id

### Quais endpoints foram afetados com essas alterações
/payments/charge e /payments/{transaction_id}/refund

### Quais testes foram feitos
Fazer charge com reference e verificar se retornar o mesmo na resposta

Fazer charge sem reference e verificar se retorna um reference gerado automaticamente

Testando em sandbox os casos acima

### Documentação
[//]: [Link](https://docs.google.com/)

### Checklist
- [ ] Validei a alteração com o time responsável pelo microsserviço
- [ ] Criei testes automatizados
- [ ] Rodei toda a suíte de testes
- [ ] Fiz testes no ambiente de QA

---
[//]: <> (Deixe a linha abaixo para cada code owner ser notificado)
Podem fazer o review, por favor?
@alice-rodriguess @andrebparpaiola @ARD @camilaPereiraOliveira @MarcosNery38 @michael-picpay @r-freitas-ppay
