### PR TITLE
[PJAF-1315] Adiciona lista de refunds na documentação do endpoint get payments

### DIFF
--- a/static/swagger/picpay-1-click-en.json
+++ b/static/swagger/picpay-1-click-en.json
@@ -1343,7 +1343,11 @@
              "description": "Format ISO 8601"
           },
           "value": {
-            "type": "integer",
+            "type": "float",
+            "example": 2.10
+          },
+          "refunded_value": {
+            "type": "float",
             "example": 2.10
           },
           "transactions": {
@@ -1382,8 +1386,34 @@
           },
           "id": {
             "type": "string"
+          },
+          "refunds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Refunds"
+            }
           }
         }
+      },
+      "Refunds": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "09950d4a-2df4-4d60-9cbc-ac8f004fa595"
+          },
+          "value": {
+            "type": "float",
+            "example": 2.10
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2023-05-29T19:25:34-03:00",
+            "description": "Format ISO 8601"
+          }
+        }
+          
       }
     }
   }

--- a/static/swagger/picpay-1-click.json
+++ b/static/swagger/picpay-1-click.json
@@ -1343,7 +1343,11 @@
             "description": "Formato ISO 8601"
           },
           "value": {
-            "type": "integer",
+            "type": "float",
+            "example": 2.10
+          },
+          "refunded_value": {
+            "type": "float",
             "example": 2.10
           },
           "transactions": {
@@ -1382,8 +1386,34 @@
           },
           "id": {
             "type": "string"
+          },
+          "refunds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Refunds"
+            }
           }
         }
+      },
+      "Refunds": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "09950d4a-2df4-4d60-9cbc-ac8f004fa595"
+          },
+          "value": {
+            "type": "float",
+            "example": 2.10
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2023-05-29T19:25:34-03:00",
+            "description": "Formato ISO 8601"
+          }
+        }
+          
       }
     }
   }


### PR DESCRIPTION
### Contexto
Com a alteração no endpoint GET v1/payments para listar os reembolsos, é necessário acrescentar as novas informações do endpoint na documentação

---
[//]: <> (Deixe a linha abaixo para cada code owner ser notificado)
Podem fazer o review, por favor?
@alice-rodriguess @andrebparpaiola @ARD @camilaPereiraOliveira @michael-picpay @r-freitas-ppay @wanderson-lima-picpay
