### PR TITLE
Fix collection url and deprecated cancel endpoint

### DIFF
--- a/docs/one-click/resources/postman-collection.md
+++ b/docs/one-click/resources/postman-collection.md
@@ -28,10 +28,6 @@ Em nossa collection, disponibilizamos os seguintes end-points:
 
 Também é um fã de postman como nós? Acesse nossa collection através do botão abaixo: 
 
-[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/e5b4593f331d1cb7fd49)
-
-Debaixo
-
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/17690805-27480f7b-9f22-4608-b978-0287f17d1ba8?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D17690805-27480f7b-9f22-4608-b978-0287f17d1ba8%26entityType%3Dcollection%26workspaceId%3Dc7921178-6410-4b4e-ac10-35d24f6a1b6d)
 
 ### Configurar suas chaves de integração

--- a/docs/one-click/resources/postman-collection.md
+++ b/docs/one-click/resources/postman-collection.md
@@ -30,6 +30,10 @@ Também é um fã de postman como nós? Acesse nossa collection através do bot�
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/e5b4593f331d1cb7fd49)
 
+Debaixo
+
+[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/17690805-27480f7b-9f22-4608-b978-0287f17d1ba8?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D17690805-27480f7b-9f22-4608-b978-0287f17d1ba8%26entityType%3Dcollection%26workspaceId%3Dc7921178-6410-4b4e-ac10-35d24f6a1b6d)
+
 ### Configurar suas chaves de integração
 
 Após importar nossa collection, você poderá configurar suas chaves dentro nas configurações de ambientes como exibido abaixo:

--- a/static/swagger/picpay-1-click.json
+++ b/static/swagger/picpay-1-click.json
@@ -146,6 +146,7 @@
     },
     "/payments/cancel": {
       "post": {
+        "deprecated": true,
         "summary": "Realizar o cancelamento de uma transação não capturada",
         "description": "Este recurso permite ao vendedor realizar o cancelamento de uma transação autorizada e aguardando captura.\nPara as transações autorizadas e aguardando captura, é permitido cancelar a transação com \nantecedência, sempre do valor total, desde que a espera esteja dentro dos 5 dias de solicitação da \ncaptura. Isso evita qualquer possibilidade de cobrança e disponibiliza o saldo da pessoa consumidora \npara novas compras.\n\nDois possíveis identificadores poderão ser usados: `transaction_id` ou `reference_id`. O `transaction_id` é o identificador PicPay retornado na cobrança realizada com sucesso. O `reference_id` é o identificador gerado pelo parceiro e enviado na requisição de cobrança. Ao menos um dos identificadores **precisa** ser enviado. Quando os dois forem enviados, ambos serão validados.",
         "operationId": "cancelPayment",
@@ -899,6 +900,7 @@
     },
     "/sandbox/payments/cancel": {
       "post": {
+        "deprecated": true,
         "summary": "Realizar o cancelamento de uma transação não capturada.",
         "description": "Este recurso permite ao vendedor realizar o cancelamento de uma transação autorizada e aguardando captura.\nPara as transações autorizadas e aguardando captura, é permitido cancelar a transação com \nantecedência, sempre do valor total, desde que a espera esteja dentro dos 5 dias de solicitação da \ncaptura. Isso evita qualquer possibilidade de cobrança e disponibiliza o saldo da pessoa consumidora \npara novas compras.\n\nDois possíveis identificadores poderão ser usados: `transaction_id` ou `reference_id`. O `transaction_id` é o identificador PicPay retornado na cobrança realizada com sucesso. O `reference_id` é o identificador gerado pelo parceiro e enviado na requisição de cobrança. Ao menos um dos identificadores **precisa** ser enviado. Quando os dois forem enviados, ambos serão validados.",
         "operationId": "SandboxCancel",

--- a/static/swagger/picpay-1-click.json
+++ b/static/swagger/picpay-1-click.json
@@ -146,7 +146,6 @@
     },
     "/payments/cancel": {
       "post": {
-        "deprecated": true,
         "summary": "Realizar o cancelamento de uma transação não capturada",
         "description": "Este recurso permite ao vendedor realizar o cancelamento de uma transação autorizada e aguardando captura.\nPara as transações autorizadas e aguardando captura, é permitido cancelar a transação com \nantecedência, sempre do valor total, desde que a espera esteja dentro dos 5 dias de solicitação da \ncaptura. Isso evita qualquer possibilidade de cobrança e disponibiliza o saldo da pessoa consumidora \npara novas compras.\n\nDois possíveis identificadores poderão ser usados: `transaction_id` ou `reference_id`. O `transaction_id` é o identificador PicPay retornado na cobrança realizada com sucesso. O `reference_id` é o identificador gerado pelo parceiro e enviado na requisição de cobrança. Ao menos um dos identificadores **precisa** ser enviado. Quando os dois forem enviados, ambos serão validados.",
         "operationId": "cancelPayment",
@@ -900,7 +899,6 @@
     },
     "/sandbox/payments/cancel": {
       "post": {
-        "deprecated": true,
         "summary": "Realizar o cancelamento de uma transação não capturada.",
         "description": "Este recurso permite ao vendedor realizar o cancelamento de uma transação autorizada e aguardando captura.\nPara as transações autorizadas e aguardando captura, é permitido cancelar a transação com \nantecedência, sempre do valor total, desde que a espera esteja dentro dos 5 dias de solicitação da \ncaptura. Isso evita qualquer possibilidade de cobrança e disponibiliza o saldo da pessoa consumidora \npara novas compras.\n\nDois possíveis identificadores poderão ser usados: `transaction_id` ou `reference_id`. O `transaction_id` é o identificador PicPay retornado na cobrança realizada com sucesso. O `reference_id` é o identificador gerado pelo parceiro e enviado na requisição de cobrança. Ao menos um dos identificadores **precisa** ser enviado. Quando os dois forem enviados, ambos serão validados.",
         "operationId": "SandboxCancel",


### PR DESCRIPTION
### Contexto
Notamos que o link da collection do Postman do serviço 1-Click está expirado, precisamos acertar isso. 

A pedido do @jefferson-pp, também precisamos "deprecar" o endpoint `/cancel` na Api Reference do 1-Click, para "forçarmos" o uso do `/refund`.

### O que foi desenvolvido
- Alterado link da collection do Postman do serviço 1-Click;
- Modificado endpoint `/cancel` do serviço 1-Click para ser "deprecated".

---
[//]: <> (Deixe a linha abaixo para cada code owner ser notificado)
Podem fazer o review, por favor?
@alice-rodriguess @andrebparpaiola @ARD @camilaPereiraOliveira @michael-picpay @r-freitas-ppay @wanderson-lima-picpay
