### PR TITLE
[PJAF-2124] Remove detalhes sobre as taxas

### DIFF
--- a/docs/checkout/intro/overview.md
+++ b/docs/checkout/intro/overview.md
@@ -13,16 +13,6 @@ Oferecendo PicPay no seu e-commerce, seus clientes efetuam o pagamento de forma 
 
 ![img](../../../static/img/guides/qrcode.png)
 
-## Taxas
-
-Você não paga taxa de adesão ou de cancelamento e seus primeiros 30 dias são gratuitos! Nos meses seguintes, é só escolher a taxa que melhor se adapta ao seu momento e quando quer receber, e vamos solicitar o pagamento de uma taxa de intermediação.
-
-| DIAS A RECEBER | TAXA |
-|--|--|
-| 1 dia | 5,19% |
-| 14 dias | 4,61% |
-| 30 dias | 3,89% |
-
 ## Funcionalidades disponíveis
 
 Atualmente, a API de e-commerce do PicPay oferece as seguintes funcionalidades:

--- a/docs/one-click/intro/overview.md
+++ b/docs/one-click/intro/overview.md
@@ -9,10 +9,6 @@ O PicPay 1-Click oferece uma forma de pagamento síncrona aos seus clientes efet
 
 Após efetuar o login em sua aplicação, o cliente autoriza cobranças em sua carteira e sua aplicação então gerencia as cobranças.
 
-## Taxas
-
-Como a funcionalidade ainda não está aberta ao público, não temos uma taxa padrão. Para saber mais sobre nossas taxas ou a solução PicPay 1-Click, entre em contato através do e-mail relacionamento-negocios@picpay.com
-
 ## Funcionalidades disponíveis.
 
 Atualmente, a API do PicPay 1-Click oferece as seguintes funcionalidades:

--- a/i18n/en/docusaurus-plugin-content-docs/current/checkout/intro/overview.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/checkout/intro/overview.md
@@ -13,16 +13,6 @@ By offering PicPay on your e-commerce platform, your customers can make secure p
 
 ![img](../../../../../../static/img/guides/qrcode.png)
 
-## Fees
-
-You don't pay an enrollment or cancellation fee, and your first 30 days are free! In the following months, you just choose the fee that best suits your situation and when you want to receive payments, and we'll charge an intermediary fee.
-
-| DAYS TO RECEIVE | FEE |
-|--|--|
-| 1 day | 5,19% |
-| 14 days | 4,61% |
-| 30 days | 3,89% |
-
 ## Available features
 
 Currently, PicPay's e-commerce API offers the following functionalities:

--- a/i18n/en/docusaurus-plugin-content-docs/current/one-click/intro/overview.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/one-click/intro/overview.md
@@ -9,10 +9,6 @@ PicPay 1-Click offers a synchronous payment method to your customers by charging
 
 After logging into your application, the customer authorizes charges to their wallet, and your application manages these charges accordingly.
 
-## Fees
-
-As the feature is not yet available to the public, we do not have a standard fee. To learn more about our fees or the PicPay 1-Click solution, please contact us at relacionamento-negocios@picpay.com.
-
 ## Available features
 
 Currently, the PicPay 1-Click API offers the following functionalities:


### PR DESCRIPTION
### Contexto
Para novos sellers do E-commerce Carteira nós sempre oferecemos a campanha de taxa zero por 30 dias devido a ausência de ambiente de testes (sandbox). Porém, devido a nova estrutura cadastral, as campanhas aplicadas a um seller afetam todos os produtos e não só o E-commerce Carteira.

Novos entrantes do Checkout (arranjo aberto) são automaticamente cadastrados no E-commerce Carteira, o que os coloca na campanha de forma indevida. E isso está afetando nossa receita com eles.

### O que foi desenvolvido
Foi removido os detalhes sobre as taxas na documentação pública do Ecommerce Wallet e do One-Click

### Documentação
[//]: [Link](https://docs.google.com/)

### Checklist
- [ ] Validei a alteração com o time responsável pelo microsserviço
- [ ] Criei testes automatizados
- [ ] Rodei toda a suíte de testes
- [ ] Fiz testes no ambiente de QA

---
[//]: <> (Deixe a linha abaixo para cada code owner ser notificado)
Podem fazer o review, por favor?
@alice-rodriguess @andrebparpaiola @ARD @camilaPereiraOliveira @michael-picpay @r-freitas-ppay @wanderson-lima-picpay
