### PR TITLE
Adição do arquivo catalog-info.yaml para reconhecimento do repositóri…

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,26 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: picpay-docs-digital-payments
+  annotations:
+    github.com/project-slug: PicPay/picpay-docs-digital-payments
+    backstage.io/kubernetes-id: "picpay-docs-digital-payments"
+    sonarqube.org/project-key: "PicPay_picpay-docs-digital-payments"
+  labels:
+    moonlight.picpay/language: javascript
+    moonlight.picpay/framework: react
+    moonlight.picpay/monitoring: dynatrace
+    moonlight.picpay/monitoring-strategy: apm
+  tags:
+    - public-documentation
+    - sfpj
+  description: |
+    A public documentation about the PicPay Ecommerce Wallet and One-Click
+  links:
+    - url: https://picpay.atlassian.net/wiki/spaces/PAC/overview?homepageId=1186988638
+      title: Confluence Docs
+      icon: dashboard
+spec:
+  lifecycle: production
+  owner: squad-ecommerce
+  type: public-documentation


### PR DESCRIPTION
…o no catálogo de serviços do Moonlight

### Contexto
O repositório da documentação não se encontra no catálogo de serviços do Moonlight. Nesse caso, é necessário adicionar o arquivo catalog-info.yaml com as informações necessárias para que o Moonlight reconheça o repositório.

### O que foi desenvolvido
Foi adicionado o arquivo catalog-info.yaml com as informações necessárias para reconhecimento do Moonlight. 

### Quais endpoints foram afetados com essas alterações
[//]: <> (PATCH /ecommerce/seller)

### Quais testes foram feitos
[//]: <> (- Atualização de taxa
- Troca de URL para callback
- Ativação de cadastro
- Desativação de cadastro
- Alteração no nome do seller)

### Documentação
[//]: [Link](https://docs.google.com/)

### Checklist
- [ ] Validei a alteração com o time responsável pelo microsserviço
- [ ] Criei testes automatizados
- [ ] Rodei toda a suíte de testes
- [ ] Fiz testes no ambiente de QA

---
[//]: <> (Deixe a linha abaixo para cada code owner ser notificado)
Podem fazer o review, por favor?
@alice-rodriguess @andrebparpaiola @ARD @camilaPereiraOliveira @michael-picpay @r-freitas-ppay @wanderson-lima-picpay
